### PR TITLE
Unblock mdl exports for non-Windows platforms

### DIFF
--- a/props/window.py
+++ b/props/window.py
@@ -314,18 +314,11 @@ class FileWindow(PropertyGroup):
         ) # type: ignore
     
     def _get_formats(self, context) -> None:
-        if self.ui_tab == 'IMPORT' or platform.system() == 'Windows':
-            return [
-            ('MDL', "MDL", "Export FBX and convert to MDL."),
-            ('FBX', "FBX", "Export FBX."),
-            ('GLTF', "GLTF", "Export GLTF"),
-            ]
-        
-        else:
-            return [
-            ('FBX', "FBX", "Export FBX."),
-            ('GLTF', "GLTF", "Export GLTF"),
-            ]
+        return [
+        ('MDL', "MDL", "Export FBX and convert to MDL."),
+        ('FBX', "FBX", "Export FBX."),
+        ('GLTF', "GLTF", "Export GLTF"),
+        ]
     
     model_format: EnumProperty(
         name="",


### PR DESCRIPTION
Right now the only thing that prevents a user on mac os or linux from exporting as mdl is this check, and all it does is stop the button from rendering. The underlying functionality works the same in all three platforms.